### PR TITLE
fix:moved a sentence on tutorial to HTML-only description

Close #1865 (#29)

### DIFF
--- a/src/tutorial/src/step-2/description.md
+++ b/src/tutorial/src/step-2/description.md
@@ -72,7 +72,7 @@ Notice how we did not need to use `.value` when accessing the `message` ref in t
 
 <div class="options-api">
 
-State that can trigger updates when changed are considered **reactive**. In Vue, reactive state is held in components. In the example code, the object being passed to `createApp()` is a component.
+State that can trigger updates when changed are considered **reactive**. In Vue, reactive state is held in components. <span class="html">In the example code, the object being passed to `createApp()` is a component.</span>
 
 We can declare reactive state using the `data` component option, which should be a function that returns an object:
 


### PR DESCRIPTION
resolves #29
Cherry picked from https://github.com/vuejs/docs/commit/2bf5476f087bb346b11372b41337a75260955053